### PR TITLE
Use proper titles for new listings

### DIFF
--- a/ebay2rss_filter.py
+++ b/ebay2rss_filter.py
@@ -27,7 +27,7 @@ try:
     <link>{escape(feed_link)}</link>""")
 
     for item in items:
-        title = item.css(".s-item__title span::text").get()
+        title = item.css(".s-item__title span[role=heading]::text").get()
         link = item.css(".s-item__link").attrib['href']
         link = re.sub(r"\?.*", "", link)
         # TODO: Add these fields to each item:


### PR DESCRIPTION
New listings were getting a wrong title (i.e. "New Listing").

```html
<div class="s-item__title">
  <span role="heading" aria-level="3">
    <span class="LIGHT_HIGHLIGHT">New Listing</span> <!-- We're getting this -->
    An extremely appealing gadget <!-- We should get this -->
  </span>
</div>
```

After this fix we'll receive the proper title.