### PR TITLE
Add migration script from url -> filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ $ git clone https://github.com/almog/newsboat-ebay2rss-filter/blob/main/ebay2rss
 ```
 "filter:~/.newsboat/newsboat-ebay2rss-filter/ebay2rss_filter.py:https://www.ebay.com/sch/i.html?&_nkw=test"
 ```
+## Migrating existing newsboat `urls` file
+`./migrate_urls <input_file> <filter_path>` transforms any ebay.com `urls` file to work with the ebay2rss filter (output is written to `stdio`)
+
+```
+./migrate_urls ~/.newsboat/urls ~/proj/newsboat-ebay2rss-filter/ebay2rss_filter.py > ./transformed_urls
+```
+Reads a `urls` file, a filter path and writes a new file `./transformed_url`.
 
 ## Logging
 Note that Newsboat filters error log is not written to Newsboat error log, therefore all filter errors are logged to `~/.newsboat/ebay2rss.log`

--- a/migrate_urls
+++ b/migrate_urls
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+import re
+import sys
+
+def is_ebay_url(url):
+    return 'ebay.com' in url
+
+def remove_rss_query_string(url):
+    return re.sub(r'&_rss=1', '', url)
+
+def is_comment(line):
+    return line.lstrip().startswith('#')
+
+def is_using_filter(feed_url, filter_path):
+    return feed_url.startswith(f'filter:{filter_path}:')
+
+def convert_file(input_file, filter_path):
+    with open(input_file, 'r') as infile:
+        for line in infile:
+            if is_comment(line):
+                sys.stdout.write(line)
+                continue
+
+            parts = line.strip().split(',', 1)
+            feed_url = parts[0].strip('"')
+            feed_description = parts[1] if len(parts) == 2 else None
+            
+            if is_using_filter(feed_url, filter_path):
+                sys.stdout.write(line)
+                continue
+
+            if is_ebay_url(feed_url):
+                cleaned_url = remove_rss_query_string(feed_url)
+                if feed_description:
+                    new_line = f'"filter:{filter_path}:{cleaned_url}", {feed_description.strip()}\n'
+                else:
+                    new_line = f'"filter:{filter_path}:{cleaned_url}"\n'
+            else:
+                new_line = line
+
+            sys.stdout.write(new_line)
+
+if len(sys.argv) < 3:
+    print(f"Usage: {sys.argv[0]} <input_file> <filter_path>")
+    sys.exit(1)
+
+input_file = sys.argv[1]  # Get input file name from the first command-line argument
+filter_path = sys.argv[2]  # Get filter path from the second command-line argument
+convert_file(input_file, filter_path)


### PR DESCRIPTION
`./migrate_urls <input_file> <filter_path>` transforms any ebay.com `urls` file to work with the ebay2rss filter (output is written to `stdio`)

```
./migrate_urls ~/.newsboat/urls ~/proj/newsboat-ebay2rss-filter/ebay2rss_filter.py > ./transformed_urls
```
Reads a `urls` file, a filter path and writes a new file `./transformed_url`.
