### PR TITLE
Fix suggested items filtering

### DIFF
--- a/ebay2rss_filter.py
+++ b/ebay2rss_filter.py
@@ -12,11 +12,11 @@ try:
     assert len(text) > 0, "Filter input must not be empty"
 
     document = Selector(text=text)
-    no_exact_match_selectors = (
-            'div:contains("We’ve streamlined your search results to show you the best listings.")',
-            'h2:contains("No exact matches found")')
+    no_exact_match_texts = (
+            'We’ve streamlined your search results to show you the best listings',
+            'No exact matches found')
 
-    has_exact_results = all(not document.css(selector) for selector in no_exact_match_selectors) 
+    has_exact_results = all(not document.css(f':contains("{text}")') for text in no_exact_match_texts)
 
     feed_description = feed_title = document.css('input[name="_nkw"]').attrib['value']
     feed_link = re.search(r'baseUrl":"(https://.*?")', text).group(1)

--- a/ebay2rss_filter.py
+++ b/ebay2rss_filter.py
@@ -8,10 +8,10 @@ from parsel import Selector
 from html import escape
 
 try:
-    text = sys.stdin.read()
-    assert len(text) > 0, "Filter input must not be empty"
+    raw_html = sys.stdin.read()
+    assert len(raw_html) > 0, "Filter input must not be empty"
 
-    document = Selector(text=text)
+    document = Selector(text=raw_html)
     assert not document.css('div :contains("There seems to be a problem serving the request at this time")'), "Ebay temporary error page returned"
 
     no_exact_match_texts = (
@@ -21,7 +21,7 @@ try:
     has_exact_results = all(not document.css(f':contains("{text}")') for text in no_exact_match_texts)
 
     feed_description = feed_title = document.css('input[name="_nkw"]').attrib['value']
-    feed_link = re.search(r'baseUrl":"(https://.*?")', text).group(1)
+    feed_link = re.search(r'baseUrl":"(https://.*?")', raw_html).group(1) #TODO: use the document rather than raw HTML
 
 
     items = document.css('.srp-river .srp-river-results .s-item__wrapper') if has_exact_results else []
@@ -62,6 +62,7 @@ try:
 
 except BaseException as err:
     with open('ebay2rss.log', 'a') as log:
+        log.write(f'{raw_html=}\n')
         log.write(f'{sys.argv=}\n')
         log.write(f'{type(err)}: {err}\n')
         log.write(traceback.format_exc())

--- a/ebay2rss_filter.py
+++ b/ebay2rss_filter.py
@@ -12,6 +12,8 @@ try:
     assert len(text) > 0, "Filter input must not be empty"
 
     document = Selector(text=text)
+    assert not document.css('div :contains("There seems to be a problem serving the request at this time")'), "Ebay temporary error page returned"
+
     no_exact_match_texts = (
             'We’ve streamlined your search results to show you the best listings',
             'No exact matches found')
@@ -61,6 +63,6 @@ try:
 except BaseException as err:
     with open('ebay2rss.log', 'a') as log:
         log.write(f'{sys.argv=}\n')
-        log.write(f'Unexpected error {type(err)}: {err}\n')
+        log.write(f'{type(err)}: {err}\n')
         log.write(traceback.format_exc())
         raise


### PR DESCRIPTION
Rather than rely on element type return empty feed if encountering any text notice whose meaning is that the search yielded no exact match